### PR TITLE
fix(azure): objectID must not contain '/' or '+'

### DIFF
--- a/src/providers/azure.js
+++ b/src/providers/azure.js
@@ -66,7 +66,9 @@ class Azure {
     }
 
     const base = {
-      objectID: Buffer.from(`${path}`).toString('base64'),
+      objectID: Buffer.from(`${path}`).toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//, '_'),
       modificationDate: Date.now(),
     };
     const object = { ...base, ...record };

--- a/src/providers/azure.js
+++ b/src/providers/azure.js
@@ -68,7 +68,7 @@ class Azure {
     const base = {
       objectID: Buffer.from(`${path}`).toString('base64')
         .replace(/\+/g, '-')
-        .replace(/\//, '_'),
+        .replace(/\//g, '_'),
       modificationDate: Date.now(),
     };
     const object = { ...base, ...record };


### PR DESCRIPTION
While indexing a document, an error occurred:
```
The request is invalid. Details: actions : 0: Invalid document key: 'ZW4vcHVibGlzaC8yMDEwLzEyLzE2L+uztOqzoOyZgC3rtoTshJ3snYAt66y07JeH7J20LeuLpOulvOq5jOyalC5odG1s'. Keys can only contain letters, digits, underscore (_), dash (-), or equal sign (=).
```
The `objectID` in the Azure index is the base64 encoding of the document path, it should be made safe from characters '/' or '+'.