### PR TITLE
fix(excel): derive destination queue name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,24 +77,6 @@
         }
       }
     },
-    "@adobe/helix-ops": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-ops/-/helix-ops-1.11.7.tgz",
-      "integrity": "sha512-KLYuiYD25yoduayaQe/7VAFopgEsMziKSpSiMQO6itNwpX/rCeAXmVg+EVJz7Rzv6xygQFXld90/V0q8azKhjA==",
-      "dev": true,
-      "requires": {
-        "@adobe/helix-fetch": "1.9.1",
-        "@adobe/helix-log": "4.5.1"
-      }
-    },
-    "@adobe/helix-testutils": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-testutils/-/helix-testutils-0.4.1.tgz",
-      "integrity": "sha512-dk52QGLxHjCW1KAFxDvXwvKwyR3m8/rjbT67mVG9faC7Wk2C2v8URfYHJzsH+fOr+u6orSU4lZcqBkedrYm3ig==",
-      "requires": {
-        "mocha": "8.1.3"
-      }
-    },
     "@adobe/helix-shared": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-7.15.0.tgz",
@@ -125,6 +107,14 @@
       "requires": {
         "@adobe/helix-fetch": "1.9.1",
         "@adobe/helix-log": "4.5.2"
+      }
+    },
+    "@adobe/helix-testutils": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-testutils/-/helix-testutils-0.4.1.tgz",
+      "integrity": "sha512-dk52QGLxHjCW1KAFxDvXwvKwyR3m8/rjbT67mVG9faC7Wk2C2v8URfYHJzsH+fOr+u6orSU4lZcqBkedrYm3ig==",
+      "requires": {
+        "mocha": "8.1.3"
       }
     },
     "@adobe/openwhisk-action-builder": {
@@ -1024,6 +1014,12 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
         }
       }
     },
@@ -1595,8 +1591,7 @@
     "@types/node": {
       "version": "14.11.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.1.tgz",
-      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw==",
-      "dev": true
+      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -6856,7 +6851,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -10235,7 +10231,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-finally": {
@@ -12591,7 +12588,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-      "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -14067,12 +14063,6 @@
       "requires": {
         "min-indent": "^1.0.0"
       }
-    },
-    "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-      "dev": true
     },
     "stubs": {
       "version": "3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -58,9 +58,11 @@ function hasParams(required, actual) {
 function createHandlers(configs, params, log) {
   const configMap = configs
     .map((config) => providers
+      // keep providers that have the required parameters and match the target
       .filter((provider) => hasParams(provider.required, params))
       .find((provider) => provider.match(config.target)))
     .reduce((map, provider, i) => {
+      // create a map of providers with their configurations in helix-query.yaml
       const name = provider ? provider.name : '(none)';
       if (!map[name]) {
         // eslint-disable-next-line no-param-reassign
@@ -79,8 +81,9 @@ function createHandlers(configs, params, log) {
         handlers = provider.create(params, providerConfigs, log);
       }
     } catch (e) {
-      log.error(`Unable to create handler in ${provider.name}`, e);
+      log.error(`Unable to create handlers in ${provider.name}`, e);
     }
+    // fill in all index definitions and their respective handler
     indices.forEach((index, i) => {
       result[index] = { config: configs[index], handler: handlers[i] };
     });

--- a/src/providers/mapResult.js
+++ b/src/providers/mapResult.js
@@ -20,9 +20,10 @@ const mapResult = {
     path,
     update,
   }),
-  accepted: (path) => ({
+  accepted: (path, update) => ({
     status: 202,
     path,
+    update,
   }),
   moved: (path, oldLocation, update) => ({
     status: 301,


### PR DESCRIPTION
In https://github.com/adobe/helix-excel-indexer/blob/91306dfc7d253ec0932db3fd7bc883a632518fd7/src/index.js#L198 the receiver queue name is derived from the GitHub coords if not present. This PR adds the same logic to the sender side.