### PR TITLE
feat(index): use normalized path from listener if available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,9 @@ function getChange(params) {
   if (observation) {
     const { change, mountpoint } = observation;
     const opts = { uid: change.uid, path: change.path, type: change.type };
-    if (mountpoint && opts.path) {
+    if (change['normalized-path']) {
+      opts.path = change['normalized-path'];
+    } else if (mountpoint && opts.path) {
       const re = new RegExp(`^${mountpoint.root}/`);
       const repl = mountpoint.path.replace(/^\/+/, '');
       opts.path = opts.path.replace(re, repl);

--- a/test/specs/excel/modified_in_de.json
+++ b/test/specs/excel/modified_in_de.json
@@ -8,7 +8,8 @@
       "type": "onedrive",
       "change": {
         "uid": "+i/8f6rBgLRF6aM3",
-        "path": "/pages/de/brown.docx",
+        "path": "/pages/de/Brown.docx",
+        "normalized-path": "/pages/de/brown.docx",
         "time": "2020-03-03T17:01:12Z",
         "type": "modified"
       },


### PR DESCRIPTION
Uses the normalized path made available with https://github.com/adobe/helix-onedrive-listener/issues/201 if present.