### PR TITLE
fix: handle change notification for gone items correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,7 @@ async function handleUpdate({
     const doc = body.docs ? body.docs[0] : null;
     return doc
       ? await handler.update({ path, ...doc })
-      : await handler.delete({ path });
+      : await handler.delete({ path, sourceHash: change.uid });
   } catch (e) {
     log.error(`An error occurred updating record ${path} in ${config.name}`, e);
     return {

--- a/test/specs/excel/modified_gone.json
+++ b/test/specs/excel/modified_gone.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "description": "change for an item that has already been deleted again",
+    "owner": "foo",
+    "repo": "bar",
+    "ref": "main",
+    "observation": {
+      "type": "onedrive",
+      "change": {
+        "uid": "T0xg9nTf1sB4huiA",
+        "path": "/pages/en/yellow.docx",
+        "time": "2020-03-03T17:01:12Z",
+        "type": "modified"
+      },
+      "provider": {
+        "driveId": "b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH"
+      }
+    }
+  },
+  "output": [{
+    "deleted": true,
+    "record": {
+      "sourceHash": "T0xg9nTf1sB4huiA"
+    }
+  }]
+}


### PR DESCRIPTION
When a OneDrive change notification for a *new* item arrives at a time when the item is already gone again, an error is logged:
```
Unable to delete record: sourceHash is empty.
```
Reason is that the `index-pipelines` action correctly reports a 404 for the gone item, which `index-files` hands over to the index provider as an actual `delete` without the `sourceHash` contained in the initial change notification.