### PR TITLE
chore(test): tests currently fail because http1 is not enforced

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+process.env.HELIX_FETCH_FORCE_HTTP1 = 'true';
+
 const assert = require('assert');
 const fse = require('fs-extra');
 const nock = require('nock');


### PR DESCRIPTION
Running the tests currently fails because the `nock` is unable to provide `helix-query.yaml` in a http2 environment. Solution is to enforce `http1` for tests.