### PR TITLE
fix: assume paths have leading slash

### DIFF
--- a/src/contains.js
+++ b/src/contains.js
@@ -36,6 +36,8 @@ function match(cfg, path, ifmissing) {
     return false;
   }
   return mm.isMatch(path, cfg
+    // prepend slash if necessary
+    .map((i) => (i.startsWith('/') || i.startsWith('**') ? i : `/${i}`))
     // expand braces in every item (creates an array of arrays)
     .map((i) => mm.braces((i)))
     // flatten to a simple array of strings

--- a/src/index.js
+++ b/src/index.js
@@ -99,21 +99,23 @@ function createHandlers(configs, params, log) {
  * @returns change object or null
  */
 function getChange(params) {
+  const addLeadingSlash = (path) => (!path.startsWith('/') ? `/${path}` : path);
   const { observation } = params;
+
   if (observation) {
     const { change, mountpoint } = observation;
     const opts = { uid: change.uid, path: change.path, type: change.type };
     if (change['normalized-path']) {
-      opts.path = change['normalized-path'];
+      opts.path = addLeadingSlash(change['normalized-path']);
     } else if (mountpoint && opts.path) {
       const re = new RegExp(`^${mountpoint.root}/`);
       const repl = mountpoint.path.replace(/^\/+/, '');
-      opts.path = opts.path.replace(re, repl);
+      opts.path = addLeadingSlash(opts.path.replace(re, repl));
     }
     return new Change(opts);
   }
   if (params.path) {
-    return new Change({ path: params.path });
+    return new Change({ path: addLeadingSlash(params.path) });
   }
   return null;
 }

--- a/src/providers/algolia.js
+++ b/src/providers/algolia.js
@@ -86,7 +86,7 @@ class Algolia {
       branch: this._branch,
       creationDate: new Date().getTime(),
       name: p.basename(path),
-      parents: makeparents(`/${path}`),
+      parents: makeparents(`${path}`),
       dir: p.dirname(path),
     };
     const object = { ...base, ...record };

--- a/test/excludes.test.js
+++ b/test/excludes.test.js
@@ -32,9 +32,9 @@ describe('Exclude tests', () => {
         'ms/posts/{2018..2019}/*.md',
       ],
     };
-    assert.equal(contains(cfg, 'ms/posts/2018/test.md'), false);
-    assert.equal(contains(cfg, 'ms/posts/2019/test.md'), false);
-    assert.equal(contains(cfg, 'ms/posts/2017/test.md'), true);
+    assert.equal(contains(cfg, '/ms/posts/2018/test.md'), false);
+    assert.equal(contains(cfg, '/ms/posts/2019/test.md'), false);
+    assert.equal(contains(cfg, '/ms/posts/2017/test.md'), true);
   });
   it('exclude containing parenthesis supported', () => {
     const cfg = {
@@ -42,21 +42,29 @@ describe('Exclude tests', () => {
         'ms/(de|en|fr)/posts/*.md',
       ],
     };
-    assert.equal(contains(cfg, 'ms/en/posts/test.md'), false);
-    assert.equal(contains(cfg, 'ms/it/posts/test.md'), true);
+    assert.equal(contains(cfg, '/ms/en/posts/test.md'), false);
+    assert.equal(contains(cfg, '/ms/it/posts/test.md'), true);
   });
   it('exclude containing all combinations supported', () => {
     const cfg = {
       exclude: [
         'ms/(de|en|fr)/posts/{2016..2020}/*.(docx|md)',
-        'ms/(de|en|fr)/archive/*.(docx|md)',
+        '/ms/(de|en|fr)/archive/*.(docx|md)',
       ],
     };
-    assert.equal(contains(cfg, 'ms/en/posts/2016/test.md'), false);
-    assert.equal(contains(cfg, 'ms/en/posts/2017/test.docx'), false);
-    assert.equal(contains(cfg, 'ms/en/posts/2021/test.md'), true);
-    assert.equal(contains(cfg, 'ms/de/archive/test.md'), false);
-    assert.equal(contains(cfg, 'ms/de/archive/test.docx'), false);
-    assert.equal(contains(cfg, 'ms/it/archive/test.md'), true);
+    assert.equal(contains(cfg, '/ms/en/posts/2016/test.md'), false);
+    assert.equal(contains(cfg, '/ms/en/posts/2017/test.docx'), false);
+    assert.equal(contains(cfg, '/ms/en/posts/2021/test.md'), true);
+    assert.equal(contains(cfg, '/ms/de/archive/test.md'), false);
+    assert.equal(contains(cfg, '/ms/de/archive/test.docx'), false);
+    assert.equal(contains(cfg, '/ms/it/archive/test.md'), true);
+  });
+  it('exclude new documents, multi-level asterisk should with leading slash', () => {
+    const cfg = {
+      exclude: [
+        '**/Document.docx',
+      ],
+    };
+    assert.equal(contains(cfg, '/ms/Document.docx'), false);
   });
 });

--- a/test/includes.test.js
+++ b/test/includes.test.js
@@ -29,12 +29,12 @@ describe('Include tests', () => {
   it('include containing braces supported', () => {
     const cfg = {
       include: [
-        'ms/posts/{2018..2019}/*.md',
+        '/ms/posts/{2018..2019}/*.md',
       ],
     };
-    assert.equal(contains(cfg, 'ms/posts/2018/test.md'), true);
-    assert.equal(contains(cfg, 'ms/posts/2019/test.md'), true);
-    assert.equal(contains(cfg, 'ms/posts/2017/test.md'), false);
+    assert.equal(contains(cfg, '/ms/posts/2018/test.md'), true);
+    assert.equal(contains(cfg, '/ms/posts/2019/test.md'), true);
+    assert.equal(contains(cfg, '/ms/posts/2017/test.md'), false);
   });
   it('include containing parenthesis supported', () => {
     const cfg = {
@@ -42,21 +42,21 @@ describe('Include tests', () => {
         'ms/(de|en|fr)/posts/*.md',
       ],
     };
-    assert.equal(contains(cfg, 'ms/en/posts/test.md'), true);
-    assert.equal(contains(cfg, 'ms/it/posts/test.md'), false);
+    assert.equal(contains(cfg, '/ms/en/posts/test.md'), true);
+    assert.equal(contains(cfg, '/ms/it/posts/test.md'), false);
   });
   it('include containing all combinations supported', () => {
     const cfg = {
       include: [
         'ms/(de|en|fr)/posts/{2016..2020}/*.(docx|md)',
-        'ms/(de|en|fr)/archive/*.(docx|md)',
+        '/ms/(de|en|fr)/archive/*.(docx|md)',
       ],
     };
-    assert.equal(contains(cfg, 'ms/en/posts/2016/test.md'), true);
-    assert.equal(contains(cfg, 'ms/en/posts/2017/test.docx'), true);
-    assert.equal(contains(cfg, 'ms/en/posts/2021/test.md'), false);
-    assert.equal(contains(cfg, 'ms/de/archive/test.md'), true);
-    assert.equal(contains(cfg, 'ms/de/archive/test.docx'), true);
-    assert.equal(contains(cfg, 'ms/it/archive/test.md'), false);
+    assert.equal(contains(cfg, '/ms/en/posts/2016/test.md'), true);
+    assert.equal(contains(cfg, '/ms/en/posts/2017/test.docx'), true);
+    assert.equal(contains(cfg, '/ms/en/posts/2021/test.md'), false);
+    assert.equal(contains(cfg, '/ms/de/archive/test.md'), true);
+    assert.equal(contains(cfg, '/ms/de/archive/test.docx'), true);
+    assert.equal(contains(cfg, '/ms/it/archive/test.md'), false);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+process.env.HELIX_FETCH_FORCE_HTTP1 = 'true';
+
 const assert = require('assert');
 const fse = require('fs-extra');
 const nock = require('nock');

--- a/test/specs/added_with_path.json
+++ b/test/specs/added_with_path.json
@@ -9,7 +9,7 @@
   },
   "output": {
     "status": 201,
-    "path": "ms/added.html",
+    "path": "/ms/added.html",
     "update": 3
   }
 }

--- a/test/specs/added_with_uid.json
+++ b/test/specs/added_with_uid.json
@@ -23,7 +23,7 @@
   },
   "output": {
     "status": 201,
-    "path": "ms/added.html",
+    "path": "/ms/added.html",
     "update": 3
   }
 }

--- a/test/specs/added_without_ext.json
+++ b/test/specs/added_without_ext.json
@@ -9,7 +9,7 @@
   },
   "output": {
     "status": 201,
-    "path": "g/added",
+    "path": "/g/added",
     "update": 3
   }
 }

--- a/test/specs/algolia/index.json
+++ b/test/specs/algolia/index.json
@@ -1,12 +1,12 @@
 [
   {
-    "path": "ms/existing.html",
+    "path": "/ms/existing.html",
     "sourceHash": "Ho7yHAYJPjonC6Do",
     "objectID": "main--ms/existing.html",
     "name": "existing"
   },
   {
-    "path": "ms/deleted.html",
+    "path": "/ms/deleted.html",
     "sourceHash": "hlNXFkdVwFlqlpof",
     "objectID": "main--ms/deleted.html",
     "name": "deleted"

--- a/test/specs/azure/index.json
+++ b/test/specs/azure/index.json
@@ -1,12 +1,12 @@
 [
   {
-    "path": "ms/existing.html",
+    "path": "/ms/existing.html",
     "sourceHash": "Ho7yHAYJPjonC6Do",
     "objectID": "main--ms/existing.html",
     "name": "existing"
   },
   {
-    "path": "ms/deleted.html",
+    "path": "/ms/deleted.html",
     "sourceHash": "hlNXFkdVwFlqlpof",
     "objectID": "main--ms/deleted.html",
     "name": "deleted"

--- a/test/specs/deleted_with_path.json
+++ b/test/specs/deleted_with_path.json
@@ -5,11 +5,11 @@
     "repo": "bar",
     "ref": "main",
     "branch": "main",
-    "path": "ms/deleted.html"
+    "path": "/ms/deleted.html"
   },
   "output": {
     "status": 204,
-    "path": "ms/deleted.html",
-    "reason": "Item gone with path: ms/deleted.html"
+    "path": "/ms/deleted.html",
+    "reason": "Item gone with path: /ms/deleted.html"
   }
 }

--- a/test/specs/deleted_with_uid.json
+++ b/test/specs/deleted_with_uid.json
@@ -21,7 +21,7 @@
   },
   "output": {
     "status": 204,
-    "path": "ms/deleted.html",
-    "reason": "Item gone with path: ms/deleted.html"
+    "path": "/ms/deleted.html",
+    "reason": "Item gone with path: /ms/deleted.html"
   }
 }

--- a/test/specs/excluded.json
+++ b/test/specs/excluded.json
@@ -9,6 +9,6 @@
   },
   "output": {
     "status": 404,
-    "reason": "Item path not in index definition: foo/Document.html"
+    "reason": "Item path not in index definition: /foo/Document.html"
   }
 }

--- a/test/specs/inexistent_with_path.json
+++ b/test/specs/inexistent_with_path.json
@@ -5,11 +5,11 @@
     "repo": "bar",
     "ref": "main",
     "branch": "main",
-    "path": "ms/inexistent.html"
+    "path": "/ms/inexistent.html"
   },
   "output": {
     "status": 404,
-    "path": "ms/inexistent.html",
-    "reason": "Item not found with path: ms/inexistent.html"
+    "path": "/ms/inexistent.html",
+    "reason": "Item not found with path: /ms/inexistent.html"
   }
 }

--- a/test/specs/moved_away.json
+++ b/test/specs/moved_away.json
@@ -23,7 +23,7 @@
   },
   "output": {
     "status": 204,
-    "path": "ms/existing.html",
-    "reason": "Item gone with path: ms/existing.html"
+    "path": "/ms/existing.html",
+    "reason": "Item gone with path: /ms/existing.html"
   }
 }

--- a/test/specs/moved_with_path.json
+++ b/test/specs/moved_with_path.json
@@ -9,8 +9,8 @@
   },
   "output": {
     "status": 301,
-    "path": "ms/moved_to.html",
-    "movedFrom": "ms/existing.html",
+    "path": "/ms/moved_to.html",
+    "movedFrom": "/ms/existing.html",
     "update": 2
   }
 }

--- a/test/specs/moved_with_uid.json
+++ b/test/specs/moved_with_uid.json
@@ -23,8 +23,8 @@
   },
   "output": {
     "status": 301,
-    "path": "ms/moved_to.html",
-    "movedFrom": "ms/existing.html",
+    "path": "/ms/moved_to.html",
+    "movedFrom": "/ms/existing.html",
     "update": 2
   }
 }

--- a/test/specs/not_included.json
+++ b/test/specs/not_included.json
@@ -9,6 +9,6 @@
   },
   "output": {
     "status": 404,
-    "reason": "Item path not in index definition: foo/added.html"
+    "reason": "Item path not in index definition: /foo/added.html"
   }
 }


### PR DESCRIPTION
Relates to https://github.com/adobe/helix-home/issues/180

Incoming paths are now assumed to have a leading slash (change in helix-onedrive-listener pending), for a smooth transition a slash is prepended if missing.

For backward compatibility, the items in the `include`/`exclude` sections will have a slash prepended if necessary.