### PR TITLE
fix: log event time if available

### DIFF
--- a/src/Change.js
+++ b/src/Change.js
@@ -13,10 +13,16 @@
 'use strict';
 
 class Change {
-  constructor({ path, uid = null, type = 'modified' }) {
+  constructor({
+    path,
+    uid = null,
+    type = 'modified',
+    time = null,
+  }) {
     this._path = path;
     this._uid = uid;
     this._type = type;
+    this._time = time;
   }
 
   get path() {
@@ -29,6 +35,10 @@ class Change {
 
   get deleted() {
     return this._type === 'deleted';
+  }
+
+  get time() {
+    return this._time;
   }
 }
 

--- a/src/providers/excel.js
+++ b/src/providers/excel.js
@@ -84,13 +84,13 @@ class Excel {
    * @returns web response
    */
   async _delete(attributes) {
-    const { sourceHash } = attributes;
+    const { sourceHash, eventTime } = attributes;
     if (!this._deletes[sourceHash]) {
       this._deletes[sourceHash] = 0;
     }
     this._deletes[sourceHash] += 1;
     if (this._deletes[sourceHash] === this._indices.length) {
-      await this._send({ deleted: true, record: { sourceHash } });
+      await this._send({ deleted: true, record: { sourceHash, eventTime } });
       this._deletes[sourceHash] = 0;
     }
     return mapResult.accepted(sourceHash, this._queueName);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,6 +203,10 @@ describe('Index Tests', () => {
             ...input,
           };
           await main(params);
+          if (!input.observation && queues[name]) {
+            // eslint-disable-next-line no-param-reassign
+            queues[name].forEach(({ record }) => delete record.eventTime);
+          }
           assert.deepStrictEqual(queues[name], output);
         }).timeout(60000);
       }
@@ -256,8 +260,8 @@ describe('Index Tests', () => {
         ...input,
       };
       await assert.rejects(
-        async () => main(params),
-        /TypeError: Cannot read property 'result' of undefined/,
+        () => main(params),
+        { name: 'TypeError' },
       );
     });
   });

--- a/test/specs/excel/deleted.json
+++ b/test/specs/excel/deleted.json
@@ -8,6 +8,7 @@
       "type": "onedrive",
       "change": {
         "uid": "+i/8f6rBgLRF6aM3",
+        "time": "2021-03-22T12:56:03Z",
         "type": "deleted"
       },
       "provider": {
@@ -18,7 +19,8 @@
   "output": [{
     "deleted": true,
     "record": {
-      "sourceHash": "+i/8f6rBgLRF6aM3"
+      "sourceHash": "+i/8f6rBgLRF6aM3",
+      "eventTime": "2021-03-22T12:56:03Z"
     }
   }]
 }

--- a/test/specs/excel/modified_gone.json
+++ b/test/specs/excel/modified_gone.json
@@ -20,7 +20,8 @@
   "output": [{
     "deleted": true,
     "record": {
-      "sourceHash": "T0xg9nTf1sB4huiA"
+      "sourceHash": "T0xg9nTf1sB4huiA",
+      "eventTime": "2020-03-03T17:01:12Z"
     }
   }]
 }

--- a/test/specs/excel/modified_in_de.json
+++ b/test/specs/excel/modified_in_de.json
@@ -26,7 +26,8 @@
       "date": 1569369600,
       "sourceHash": "+i/8f6rBgLRF6aM3",
       "title": "I feel good",
-      "genres": ["Soul", "Funk", "Rhythm and Blues"]
+      "genres": ["Soul", "Funk", "Rhythm and Blues"],
+      "eventTime": "2020-03-03T17:01:12Z"
     }
   }]
 }

--- a/test/specs/excel/modified_in_en.json
+++ b/test/specs/excel/modified_in_en.json
@@ -25,7 +25,8 @@
       "date": 1569369600,
       "sourceHash": "hlNXFkdVwFlqlpof",
       "title": "I feel good",
-      "genres": ["Soul", "Funk", "Rhythm and Blues"]
+      "genres": ["Soul", "Funk", "Rhythm and Blues"],
+      "eventTime": "2020-03-03T17:01:12Z"
     }
   }]
 }

--- a/test/specs/excel/modified_in_jp.json
+++ b/test/specs/excel/modified_in_jp.json
@@ -25,7 +25,8 @@
       "date": 1569369600,
       "sourceHash": "Ho7yHAYJPjonC6Do",
       "title": "I feel good",
-      "genres": [ "Soul", "Funk", "Rhythm and Blues" ]
+      "genres": [ "Soul", "Funk", "Rhythm and Blues" ],
+      "eventTime": "2020-03-03T17:01:12Z"
     }
   }]
 }

--- a/test/specs/excel/modified_outside.json
+++ b/test/specs/excel/modified_outside.json
@@ -20,7 +20,8 @@
   "output": [{
     "deleted": true,
     "record": {
-      "sourceHash": "8qRlJYKzHfuDcbjN"
+      "sourceHash": "8qRlJYKzHfuDcbjN",
+      "eventTime": "2020-03-03T17:01:12Z"
     }
   }]
 }


### PR DESCRIPTION
relates to https://github.com/adobe/helix-excel-indexer/pull/102

In order to debug issues where phantom updates for already deleted items appeared, we additionally log the time a message was received by the onedrive (or other) listener.