### PR TITLE
fix: add reason to error message

### DIFF
--- a/src/index-pipelines.js
+++ b/src/index-pipelines.js
@@ -47,7 +47,7 @@ async function run(pkgPrefix, params, path) {
   Object.values(results).forEach((r) => {
     const { error } = r;
     if (error && error.status !== 404) {
-      const message = `${action} failed for path: ${path}, status: ${error.status}`;
+      const message = `${action} failed for path: ${path}, reason: ${error.reason}, status: ${error.status}`;
       throw new OpenWhiskError(message, null, error.status);
     }
   });


### PR DESCRIPTION
will add the reason (e.g. `document not complete`) to the error message