### PR TITLE
fix: handle string result body as well

### DIFF
--- a/src/index-pipelines.js
+++ b/src/index-pipelines.js
@@ -39,7 +39,11 @@ async function run(pkgPrefix, params, path) {
     },
   });
 
-  const results = result.body;
+  let results = result.body;
+  if (typeof results === 'string') {
+    // universal runtime returns JSON as string to parse
+    results = JSON.parse(results);
+  }
   if (!results) {
     const message = `${action} (activation id: ${activationId}) returned no body`;
     throw new OpenWhiskError(message, null, 500);

--- a/test/index-pipelines.test.js
+++ b/test/index-pipelines.test.js
@@ -71,6 +71,19 @@ describe('Index Pipeline Tests', () => {
     )(pkgPrefix, { version: '1.0.0', ...params }, path);
     assert.equal(actionName, 'helix-observation/index-pipelines@1.0.0');
   });
+  it('returning a string body works too', async () => {
+    let actionName;
+    await run(
+      ({ name }) => {
+        actionName = name;
+        return {
+          activationId: 'e56b6142faf74ee7ab6142faf76ee7a6',
+          response: { result: { body: '{ "docs": [] }' } },
+        };
+      },
+    )(pkgPrefix, { version: '1.0.0', ...params }, path);
+    assert.equal(actionName, 'helix-observation/index-pipelines@1.0.0');
+  });
   it('returning no body element throws', async () => {
     await assert.rejects(
       () => run(


### PR DESCRIPTION
related to https://github.com/adobe/helix-index-pipelines/pull/455

After converting helix-index-pipelines universal, the response body is no longer a JSON object, but a string, so expect to handle both.